### PR TITLE
Cleanup datamodel

### DIFF
--- a/docs/project_descriptor.md
+++ b/docs/project_descriptor.md
@@ -89,28 +89,14 @@ ProjectDescriptor Structur:
 
 #### storage classes
 
-| Field                         | Description                                                           |
-|-------------------------------|-----------------------------------------------------------------------|
-| __name__                      | The name of the storage class                                         |
-| __provisioner__               | The provisioner used by this storage class                            |
-| __reclaim_policy__            | The reclaim policy of this storage class                              |
-| __volume_bind_mode__          | The volume bind mode of this storage class                            |
-| __parameters__                | key value map of parameters                                           |
-| __mount_options__             | array of options to mount the volumes of this storage class           |
-| __create_persistent_volumes__ | If persistent volumes should be precreated for this storage class     |
-| __persistent_volume_groups__  | The list of persistent volume groups to create for this storage class |
-
-#### persistent volume group
-
-| Field             | Description                                                             |
-|-------------------|-------------------------------------------------------------------------|
-| __name__          | The name of the persistent volume group                                 |
-| __type__          | The Type of the persistent volume group (__only "local" is supportet__) |
-| __path__          | For local persistent volumes the path pattern to use                    |
-| __create_script__ | For log informations the hint how to create the required directories.   |
-| __access_modes__  | List of access modes (string array)                                     |
-| __capacity__      | The capacity of the persistent volumes to create                        |
-| __nodes__         | For local persistent volumes the ist of nodes to bound (string array).  |
+| Field                | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| __name__             | The name of the storage class                               |
+| __provisioner__      | The provisioner used by this storage class                  |
+| __reclaim_policy__   | The reclaim policy of this storage class                    |
+| __volume_bind_mode__ | The volume bind mode of this storage class                  |
+| __parameters__       | key value map of parameters                                 |
+| __mount_options__    | array of options to mount the volumes of this storage class |
 
 #### persistent volume
 

--- a/docs/project_descriptor.md
+++ b/docs/project_descriptor.md
@@ -41,12 +41,12 @@ ProjectDescriptor Structur:
 
 #### resources
 
-| Field                 | Description                          |
-|-----------------------|--------------------------------------|
-| __certificates__      | Array of certificates to deploy      |
-| __config_maps__       | Array of config maps to deploy       |
-| __docker_credential__ | Array of docker credential to deploy |
-| __secrets__           | Array of secrets to deploy           |
+| Field                  | Description                          |
+|------------------------|--------------------------------------|
+| __certificates__       | Array of certificates to deploy      |
+| __config_maps__        | Array of config maps to deploy       |
+| __docker_credentials__ | Array of docker credential to deploy |
+| __secrets__            | Array of secrets to deploy           |
 
 #### certificate
 

--- a/internal/pkg/assert/assert.go
+++ b/internal/pkg/assert/assert.go
@@ -15,12 +15,26 @@
 package assert
 
 import (
+	"flag"
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"testing"
 )
+
+var Update = flag.Bool("update", false, "update .golden files")
+
+func AssertGoldenFile(tb testing.TB, testName string, actual []byte) {
+	golden := fmt.Sprintf("testdata/golden-files/%s.golden", testName)
+	if *Update {
+		ioutil.WriteFile(golden, actual, 0644)
+	}
+	expected, err := ioutil.ReadFile(golden)
+	Ok(tb, err)
+	Equals(tb, string(expected), string(actual))
+}
 
 // assert fails the test if the condition is false.
 func Assert(tb testing.TB, condition bool, msg string, v ...interface{}) {

--- a/internal/pkg/rancher/model.go
+++ b/internal/pkg/rancher/model.go
@@ -91,24 +91,12 @@ type RegistryCredential struct {
 }
 
 type StorageClass struct {
-	Name                    string
-	Provisioner             string
-	ReclaimPolicy           string                  `yaml:"reclaim_policy"`
-	VolumeBindMode          string                  `yaml:"volume_bind_mode"`
-	Parameters              map[string]string       `yaml:"parameters,omitempty"`
-	MountOptions            []string                `yaml:"mount_options,omitempty"`
-	CreatePersistentVolumes bool                    `yaml:"create_persistent_volumes,omitempty"`
-	PersistentVolumeGroups  []PersistentVolumeGroup `yaml:"persistent_volume_groups,omitempty"`
-}
-
-type PersistentVolumeGroup struct {
-	Name         string
-	Type         string
-	Path         string
-	CreateScript string   `yaml:"create_script"`
-	AccessModes  []string `yaml:"access_modes"`
-	Capacity     string
-	Nodes        []string
+	Name           string
+	Provisioner    string
+	ReclaimPolicy  string            `yaml:"reclaim_policy"`
+	VolumeBindMode string            `yaml:"volume_bind_mode"`
+	Parameters     map[string]string `yaml:"parameters,omitempty"`
+	MountOptions   []string          `yaml:"mount_options,omitempty"`
 }
 
 type PersistentVolume struct {

--- a/internal/pkg/rancher/model.go
+++ b/internal/pkg/rancher/model.go
@@ -61,7 +61,7 @@ type Namespace struct {
 type Resources struct {
 	Certificates      []Certificate      `yaml:"certificates,omitempty"`
 	ConfigMaps        []ConfigMap        `yaml:"config_maps,omitempty"`
-	DockerCredentials []DockerCredential `yaml:"docker_credential,omitempty"`
+	DockerCredentials []DockerCredential `yaml:"docker_credentials,omitempty"`
 	Secrets           []ConfigMap        `yaml:"secrets,omitempty"`
 }
 

--- a/internal/pkg/rancher/project/parser_test.go
+++ b/internal/pkg/rancher/project/parser_test.go
@@ -55,11 +55,12 @@ func TestErrorOnParsingClusterDescriptor(t *testing.T) {
 }
 
 func TestParseValidProjectDescriptor(t *testing.T) {
+	testName := "valid-project"
 	//Arrange
 	parser := NewParser("testdata/valid-project/project.yaml")
 
 	values := make(map[string]interface{})
-	if data, err := ioutil.ReadFile("testdata/valid-project/values.yaml"); err != nil {
+	if data, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s/values.yaml", testName)); err != nil {
 		log.Fatal(err)
 	} else if err := yaml.Unmarshal(data, &values); err != nil {
 		log.Fatal(err)
@@ -70,28 +71,7 @@ func TestParseValidProjectDescriptor(t *testing.T) {
 
 	//Verify
 	assert.Ok(t, err)
-	assert.Equals(t, "v1.0", project.APIVersion)
-	assert.Equals(t, "Project", project.Kind)
-	assert.Equals(t, "https://ui.rancher.server", project.Metadata.RancherURL)
-	assert.Equals(t, "token-12345", project.Metadata.AccessKey)
-	assert.Equals(t, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", project.Metadata.SecretKey)
-	assert.Equals(t, "token-12345:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", project.Metadata.TokenKey)
-	assert.Equals(t, "my-wordpress-dev", project.Metadata.Name)
-	assert.Equals(t, "j-4444", project.Metadata.ClusterID)
-	assert.Equals(t, 1, len(project.Namespaces))
-	assert.Equals(t, "my-wordpress-dev-web", project.Namespaces[0].Name)
-	assert.Equals(t, 1, len(project.StorageClasses))
-	assert.Equals(t, "my-wordpress-dev-local-mariadb", project.StorageClasses[0].Name)
-	assert.Equals(t, "kubernetes.io/no-provisioner", project.StorageClasses[0].Provisioner)
-	assert.Equals(t, "Delete", project.StorageClasses[0].ReclaimPolicy)
-	assert.Equals(t, true, project.StorageClasses[0].CreatePersistentVolumes)
-	assert.Equals(t, "WaitForFirstConsumer", project.StorageClasses[0].VolumeBindMode)
-	assert.Equals(t, 1, len(project.StorageClasses[0].PersistentVolumeGroups))
-	assert.Equals(t, "my-wordpress-dev-mariadb", project.StorageClasses[0].PersistentVolumeGroups[0].Name)
-	assert.Equals(t, "local", project.StorageClasses[0].PersistentVolumeGroups[0].Type)
-	assert.Equals(t, []string{"ReadWriteOnce"}, project.StorageClasses[0].PersistentVolumeGroups[0].AccessModes)
-	assert.Equals(t, "3Gi", project.StorageClasses[0].PersistentVolumeGroups[0].Capacity)
-	assert.Equals(t, "/var/data/my-wordpress-dev-mariadb", project.StorageClasses[0].PersistentVolumeGroups[0].Path)
-	assert.Equals(t, []string{"node-1", "node-2", "node-3"}, project.StorageClasses[0].PersistentVolumeGroups[0].Nodes)
-	assert.Equals(t, "ssh ${node} sudo mkdir -p ${path}", project.StorageClasses[0].PersistentVolumeGroups[0].CreateScript)
+	actual, err := yaml.Marshal(project)
+	assert.Ok(t, err)
+	assert.AssertGoldenFile(t, testName, actual)
 }

--- a/internal/pkg/rancher/project/testdata/golden-files/valid-project.golden
+++ b/internal/pkg/rancher/project/testdata/golden-files/valid-project.golden
@@ -1,0 +1,97 @@
+api_version: v1.0
+kind: Project
+metadata:
+  name: my-wordpress-dev
+  rancher_url: https://ui.rancher.server
+  access_key: token-12345
+  secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  token_key: token-12345:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  cluster_id: j-4444
+namespaces:
+- name: my-wordpress-dev-web
+resources:
+  certificates:
+  - name: wts-test
+    key: |
+      -----BEGIN PRIVATE KEY-----
+        ...
+        ...
+      -----END PRIVATE KEY-----
+    certs: |
+      -----BEGIN CERTIFICATE-----
+        ...
+        ...
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+        ...
+        ...
+      -----END CERTIFICATE-----
+  - name: wts-test-2
+    key: |
+      -----BEGIN PRIVATE KEY-----
+        ...
+        ...
+      -----END PRIVATE KEY-----
+    certs: |
+      -----BEGIN CERTIFICATE-----
+        ...
+        ...
+      -----END CERTIFICATE-----
+      -----BEGIN CERTIFICATE-----
+        ...
+        ...
+      -----END CERTIFICATE-----
+    namespace: editorial
+  config_maps:
+  - name: wts-test
+    data:
+      abc: def
+      bca: fed
+  docker_credentials:
+  - name: my-registry
+    registries:
+    - name: my.private.registry
+      password: my-docker-registry-password
+      username: my-docker-registry-user
+  secrets:
+  - name: wts-test
+    data:
+      abc: def
+      bca: fed
+storage_classes:
+- name: my-wordpress-dev-local-mariadb
+  provisioner: kubernetes.io/no-provisioner
+  reclaim_policy: Delete
+  volume_bind_mode: WaitForFirstConsumer
+  create_persistent_volumes: true
+  persistent_volume_groups:
+  - name: my-wordpress-dev-mariadb
+    type: local
+    path: /var/data/my-wordpress-dev-mariadb
+    create_script: ssh ${node} sudo mkdir -p ${path}
+    access_modes:
+    - ReadWriteOnce
+    capacity: 3Gi
+    nodes:
+    - node-1
+    - node-2
+    - node-3
+apps:
+- name: editorial-namespace
+  catalog: library
+  chart: wordpress
+  version: 2.1.10
+  namespace: my-wordpress-dev-web
+  answers:
+    ingress.enabled: "false"
+    license: dGVzdC1kYXRhCg==
+    mariadb.db.name: wordpress
+    mariadb.db.user: wordpress
+    mariadb.enabled: "true"
+    mariadb.master.persistence.enabled: "true"
+    mariadb.master.persistence.size: 8Gi
+    mariadb.master.persistence.storageClass: my-wordpress-dev-local-mariadb
+    serviceType: ClusterIP
+    wordpressEmail: user@example.com
+    wordpressPassword: ""
+    wordpressUsername: user

--- a/internal/pkg/rancher/project/testdata/golden-files/valid-project.golden
+++ b/internal/pkg/rancher/project/testdata/golden-files/valid-project.golden
@@ -63,19 +63,6 @@ storage_classes:
   provisioner: kubernetes.io/no-provisioner
   reclaim_policy: Delete
   volume_bind_mode: WaitForFirstConsumer
-  create_persistent_volumes: true
-  persistent_volume_groups:
-  - name: my-wordpress-dev-mariadb
-    type: local
-    path: /var/data/my-wordpress-dev-mariadb
-    create_script: ssh ${node} sudo mkdir -p ${path}
-    access_modes:
-    - ReadWriteOnce
-    capacity: 3Gi
-    nodes:
-    - node-1
-    - node-2
-    - node-3
 apps:
 - name: editorial-namespace
   catalog: library

--- a/internal/pkg/rancher/project/testdata/valid-project/project.yaml
+++ b/internal/pkg/rancher/project/testdata/valid-project/project.yaml
@@ -55,13 +55,6 @@ resources:
       abc: def
       bca: fed
     namespaceId: ksb-nightly3-editorial
-  docker_credential:
-  - name: wts
-    registries:
-    - name: docker.bitgrip.berlin
-      username: abc
-      password: def
-    namespace: ksb-nightly3-editorial (optional)
   secrets:
   - name: wts-test
     data:

--- a/internal/pkg/rancher/project/testdata/valid-project/project.yaml
+++ b/internal/pkg/rancher/project/testdata/valid-project/project.yaml
@@ -43,6 +43,12 @@ resources:
         ...
       -----END CERTIFICATE-----
     namespace: editorial
+  docker_credentials:
+  - name: 	my-registry
+    registries:
+    - name: my.private.registry
+      username: {{ .docker_user }}
+      password: {{ .docker_password }}
   config_maps:
   - name: wts-test
     data:

--- a/internal/pkg/rancher/project/testdata/valid-project/values.yaml
+++ b/internal/pkg/rancher/project/testdata/valid-project/values.yaml
@@ -3,3 +3,5 @@ stage: dev
 license_file: testdata/valid-project/license.file
 expected_license_file_value: dGVzdC1kYXRhCg==
 use_local_volumes: true
+docker_user: my-docker-registry-user
+docker_password: my-docker-registry-password

--- a/internal/pkg/template/template_test.go
+++ b/internal/pkg/template/template_test.go
@@ -15,7 +15,6 @@
 package template
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,8 +22,6 @@ import (
 
 	"github.com/bitgrip/cattlectl/internal/pkg/assert"
 )
-
-var update = flag.Bool("update", false, "update .golden files")
 
 func TestGoldenFileTestCases(t *testing.T) {
 	testdirs, err := ioutil.ReadDir("testdata")
@@ -54,7 +51,7 @@ func runTestCase(testName string, truncated bool, t *testing.T) {
 	actual, err := BuildTemplate(templateData, values, truncated)
 	assert.Ok(t, err)
 	golden := fmt.Sprintf("%s-%v.golden", testName, truncated)
-	if *update {
+	if *assert.Update {
 		ioutil.WriteFile(golden, actual, 0644)
 	}
 	expected, err := ioutil.ReadFile(golden)


### PR DESCRIPTION
Some cleanup work regarding the datamodel.

use docker_credentials instead of docker_credential for array of DockerCredential.
remove deprecated persistent_volume_groups from storage_class.

Closes #10
Closes #11
