### PR TITLE
Add support for multiple values files (#25)

### DIFF
--- a/cmd/apply/apply.go
+++ b/cmd/apply/apply.go
@@ -35,7 +35,7 @@ var (
 		Run:   apply,
 	}
 	applyFile   string
-	valuesFile  string
+	valuesFiles []string
 	rootConfig  config.Config
 	initCommand = func() {}
 )
@@ -55,7 +55,7 @@ func BaseCommand(config config.Config, init func()) *cobra.Command {
 
 func apply(cmd *cobra.Command, args []string) {
 	initCommand()
-	values, err := utils.LoadValues(valuesFile)
+	values, err := utils.LoadValues(valuesFiles...)
 	if err != nil {
 		logrus.WithField("apply_file", applyFile).
 			Fatal(err)
@@ -82,5 +82,5 @@ func apply(cmd *cobra.Command, args []string) {
 
 func init() {
 	applyCmd.Flags().StringVarP(&applyFile, "file", "f", "project.yaml", "project file to apply")
-	applyCmd.Flags().StringVar(&valuesFile, "values", "values.yaml", "values file to apply")
+	applyCmd.Flags().StringSliceVar(&valuesFiles, "values", []string{"values.yaml"}, "values file(s) to apply")
 }

--- a/cmd/show/show.go
+++ b/cmd/show/show.go
@@ -36,7 +36,7 @@ var (
 		Run:   show,
 	}
 	showFile    string
-	valuesFile  string
+	valuesFiles []string
 	rootConfig  config.Config
 	initCommand func()
 )
@@ -52,7 +52,7 @@ func BaseCommand(config config.Config, init func()) *cobra.Command {
 
 func show(cmd *cobra.Command, args []string) {
 	initCommand()
-	values, err := utils.LoadValues(valuesFile)
+	values, err := utils.LoadValues(valuesFiles...)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -74,5 +74,5 @@ func show(cmd *cobra.Command, args []string) {
 
 func init() {
 	showCmd.Flags().StringVarP(&showFile, "file", "f", "project.yaml", "project file to show")
-	showCmd.Flags().StringVar(&valuesFile, "values", "values.yaml", "values file to show")
+	showCmd.Flags().StringSliceVar(&valuesFiles, "values", []string{"values.yaml"}, "values file(s) to show")
 }

--- a/cmd/utils/testdata/values.1.yaml
+++ b/cmd/utils/testdata/values.1.yaml
@@ -1,0 +1,9 @@
+key1: value1
+key_with_underliner: value1 from key with underliner
+storage_class:
+  azure:
+    provisioner: kubernetes.io/azure-disk
+    volume_binding_mode: Immediate
+    parameters:
+      kind: Managed
+      storageaccounttype: Standard_LRS

--- a/cmd/utils/testdata/values.2.yaml
+++ b/cmd/utils/testdata/values.2.yaml
@@ -1,0 +1,7 @@
+key2: value2
+key_with_underliner: value2 from key with underliner
+storage_class:
+  azure:
+    parameters:
+      cachingmode: None
+      storageaccounttype: Premium_LRS

--- a/cmd/utils/testdata/values.expected.yaml
+++ b/cmd/utils/testdata/values.expected.yaml
@@ -1,0 +1,11 @@
+key1: value1
+key2: value2
+key_with_underliner: value2 from key with underliner
+storage_class:
+  azure:
+    provisioner: kubernetes.io/azure-disk
+    volume_binding_mode: Immediate
+    parameters:
+      cachingmode: None
+      kind: Managed
+      storageaccounttype: Premium_LRS

--- a/cmd/utils/values_test.go
+++ b/cmd/utils/values_test.go
@@ -26,6 +26,9 @@ import (
 func TestComplexValuesStructure(t *testing.T) {
 	const valuesFile = "testdata/values-with-structure.yaml"
 	os.Setenv("STORAGE_CLASS_AZURE_VOLUME_BINDING_MODE", "changed-bind-mode")
+	defer func() {
+		os.Unsetenv("STORAGE_CLASS_AZURE_VOLUME_BINDING_MODE")
+	}()
 
 	expected := make(map[string]interface{}, 0)
 	fileContent, err := ioutil.ReadFile(valuesFile)
@@ -65,6 +68,9 @@ func TestPlainValuesStructure(t *testing.T) {
 func TestChangeValueByEnvironmentVariable(t *testing.T) {
 	const valuesFile = "testdata/values.yaml"
 	os.Setenv("KEY1", "altered-by-env")
+	defer func() {
+		os.Unsetenv("KEY1")
+	}()
 
 	expected := make(map[string]interface{}, 0)
 	fileContent, err := ioutil.ReadFile(valuesFile)
@@ -85,13 +91,6 @@ func TestFailWhenValuesKeysAreMissformated(t *testing.T) {
 	assert.NotOk(t, err, "uppercase characters are not allowed on value keys")
 }
 
-func TestBla(t *testing.T) {
-	const valuesFile = "testdata/values-with-structure.yaml"
-
-	_, err := LoadValues(valuesFile)
-	assert.Ok(t, err)
-}
-
 func TestNotExistingValuesFile(t *testing.T) {
 	const valuesFile = "testdata/not-existing-values.yaml"
 
@@ -99,5 +98,35 @@ func TestNotExistingValuesFile(t *testing.T) {
 
 	actual, err := LoadValues(valuesFile)
 	assert.Ok(t, err)
+	assert.Equals(t, expected, actual)
+}
+
+func TestEmptyFileList(t *testing.T) {
+	expected := make(map[string]interface{}, 0)
+
+	actual, err := LoadValues()
+	assert.Ok(t, err)
+	assert.Equals(t, expected, actual)
+}
+
+func TestMultipleFileList(t *testing.T) {
+	const valuesFile1 = "testdata/values.1.yaml"
+	const valuesFile2 = "testdata/values.2.yaml"
+	const valuesFileExpected = "testdata/values.expected.yaml"
+
+	expected := make(map[string]interface{}, 0)
+
+	fileContent, err := ioutil.ReadFile(valuesFileExpected)
+	assert.Ok(t, err)
+	err = yaml.Unmarshal(fileContent, &expected)
+	assert.Ok(t, err)
+
+	actual, err := LoadValues(valuesFile1, valuesFile2)
+	assert.Ok(t, err)
+
+	actualData, err := yaml.Marshal(actual)
+	assert.Ok(t, err)
+	err = yaml.Unmarshal(actualData, &actual)
+
 	assert.Equals(t, expected, actual)
 }

--- a/docs/cattlectl_apply.md
+++ b/docs/cattlectl_apply.md
@@ -24,9 +24,9 @@ cattlectl apply [flags]
 ### Options
 
 ```
-  -f, --file string     project file to apply (default "project.yaml")
-  -h, --help            help for apply
-      --values string   values file to apply (default "values.yaml")
+  -f, --file string      project file to apply (default "project.yaml")
+  -h, --help             help for apply
+      --values strings   values file(s) to apply (default [values.yaml])
 ```
 
 ### Options inherited from parent commands

--- a/docs/cattlectl_show.md
+++ b/docs/cattlectl_show.md
@@ -15,9 +15,9 @@ cattlectl show [flags]
 ### Options
 
 ```
-  -f, --file string     project file to show (default "project.yaml")
-  -h, --help            help for show
-      --values string   values file to show (default "values.yaml")
+  -f, --file string      project file to show (default "project.yaml")
+  -h, --help             help for show
+      --values strings   values file(s) to show (default [values.yaml])
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.3.0
-	github.com/spf13/afero v1.2.1 // indirect
+	github.com/spf13/afero v1.2.1
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/testify v1.3.0 // indirect


### PR DESCRIPTION
* The flag `--values`  can be used multiple times.
* The content of the files is merged.
* The following files may overwrite values from former files

Closes #25
