### PR TITLE
Fix help text of delete flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
       * enableServiceLinks
       * overhead
       * preemptionPolicy
+* Fix help text of delete flags (#54)
 
 ### Removed
 

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -70,9 +70,9 @@ func delete(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	deleteCmd.Flags().String("project-name", "", "The name of the project to list resouces from")
+	deleteCmd.Flags().String("project-name", "", "The name of the project to delete resouces from")
 	viper.BindPFlag("delete_cmd.project_name", deleteCmd.Flags().Lookup("project-name"))
 
-	deleteCmd.Flags().String("namespace", "", "The namespace of the project to list resouces from")
+	deleteCmd.Flags().String("namespace", "", "The namespace of the project to delete resouces from")
 	viper.BindPFlag("delete_cmd.namespace", deleteCmd.Flags().Lookup("namespace"))
 }

--- a/docs/cli/cattlectl_delete.md
+++ b/docs/cli/cattlectl_delete.md
@@ -28,8 +28,8 @@ cattlectl delete KIND NAME [flags]
 
 ```
   -h, --help                  help for delete
-      --namespace string      The namespace of the project to list resouces from
-      --project-name string   The name of the project to list resouces from
+      --namespace string      The namespace of the project to delete resouces from
+      --project-name string   The name of the project to delete resouces from
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
updated help text for flags `--project-name` and `--namespace`

Closes #46 
