### PR TITLE
fix the transfer of the apply values to the controler

### DIFF
--- a/ansible/cattlectl_apply/main.go
+++ b/ansible/cattlectl_apply/main.go
@@ -77,7 +77,7 @@ func main() {
 	result, err := ctl.ApplyDescriptor(
 		moduleArgs.ApplyFile,
 		projectData,
-		map[string]interface{}{},
+		values,
 		utils.BuildRancherConfig(moduleArgs.AccessArgs),
 	)
 


### PR DESCRIPTION
Fixing the missing values for the `apply descriptor` action.
This has caused failing applys on descriptors with `includes`
